### PR TITLE
Backend API - Jest Sad & Error Path Tests

### DIFF
--- a/backend/.eslintrc.yml
+++ b/backend/.eslintrc.yml
@@ -4,10 +4,8 @@ parser: '@typescript-eslint/parser'
 extends:
   - 'eslint:recommended'
   - 'plugin:@typescript-eslint/recommended'
-  - 'plugin:jest/recommended'
 plugins:
   - '@typescript-eslint'
-  - 'jest'
 rules:
   jest/no-export: off
   '@typescript-eslint/no-explicit-any': off

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -21,7 +21,8 @@ export default {
     ]
   },
   testMatch: ['<rootDir>/dist/test/**/*.test.js'],
-  testPathIgnorePatterns: ['/node_modules/,'],
+  testPathIgnorePatterns: ['/node_modules/'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/test/'],
   transformIgnorePatterns: ['/node_modules/', '/dist/'],
   // All imported modules in your tests should be mocked automatically
   automock: false,

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "coverage": "yarn test -coverage --silent --ci --testLocationInResults --json --outputFile=\"report.json\"",
     "test-debug": "yarn build && DEBUG=express:* NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-vm-modules node node_modules/.bin/jest --runInBand --verbose --coverage --config jest.config.js",
     "test-debug-devtools": "yarn build && NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-vm-modules node --no-lazy --inspect-brk node_modules/.bin/jest --runInBand --verbose --coverage --config jest.config.js",
-    "coverage": "jest -coverage --silent --ci --testLocationInResults --json --outputFile=\"report.json\"",
+    "coverage": "yarn test -coverage --silent --ci --testLocationInResults --json --outputFile=\"report.json\"",
     "start": "NODE_NO_WARNINGS=1 node --no-lazy --loader ts-node/esm ./bin/www.ts",
     "start-debug": "DEBUG=express:* NODE_NO_WARNINGS=1 node --loader ts-node/esm ./bin/www.ts",
     "start-debug-devtools": "DEBUG=express:* NODE_NO_WARNINGS=1 node --no-lazy --inspect-brk --loader ts-node/esm ./bin/www.ts",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,6 @@
     "coverage": "yarn test -coverage --silent --ci --testLocationInResults --json --outputFile=\"report.json\"",
     "test-debug": "yarn build && DEBUG=express:* NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-vm-modules node node_modules/.bin/jest --runInBand --verbose --coverage --config jest.config.js",
     "test-debug-devtools": "yarn build && NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-vm-modules node --no-lazy --inspect-brk node_modules/.bin/jest --runInBand --verbose --coverage --config jest.config.js",
-    "coverage": "yarn test -coverage --silent --ci --testLocationInResults --json --outputFile=\"report.json\"",
     "start": "NODE_NO_WARNINGS=1 node --no-lazy --loader ts-node/esm ./bin/www.ts",
     "start-debug": "DEBUG=express:* NODE_NO_WARNINGS=1 node --loader ts-node/esm ./bin/www.ts",
     "start-debug-devtools": "DEBUG=express:* NODE_NO_WARNINGS=1 node --no-lazy --inspect-brk --loader ts-node/esm ./bin/www.ts",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "coverage": "yarn test -coverage --silent --ci --testLocationInResults --json --outputFile=\"report.json\"",
     "test-debug": "yarn build && DEBUG=express:* NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-vm-modules node node_modules/.bin/jest --runInBand --verbose --coverage --config jest.config.js",
     "test-debug-devtools": "yarn build && NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-vm-modules node --no-lazy --inspect-brk node_modules/.bin/jest --runInBand --verbose --coverage --config jest.config.js",
+    "coverage": "jest -coverage --silent --ci --testLocationInResults --json --outputFile=\"report.json\"",
     "start": "NODE_NO_WARNINGS=1 node --no-lazy --loader ts-node/esm ./bin/www.ts",
     "start-debug": "DEBUG=express:* NODE_NO_WARNINGS=1 node --loader ts-node/esm ./bin/www.ts",
     "start-debug-devtools": "DEBUG=express:* NODE_NO_WARNINGS=1 node --no-lazy --inspect-brk --loader ts-node/esm ./bin/www.ts",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,8 @@
     "dev": "nodemon",
     "dev-docker": "nodemon -L",
     "seed": "NODE_NO_WARNINGS=1 node --loader ts-node/esm prisma/seed.ts",
-    "prisma-setup": "prisma generate && prisma migrate deploy"
+    "prisma-setup": "prisma generate && prisma migrate deploy",
+    "list-routes": "NODE_NO_WARNINGS=1 node --no-lazy --loader ts-node/esm ./test/list-routes.ts && cat routes.json | jq -r '.[] | \"\\(.methods[0]): \\(.path)\"'"
   },
   "dependencies": {
     "@prisma/client": "^5.9.1",
@@ -35,12 +36,14 @@
     "@types/cors": "^2.8.17",
     "@types/debug": "^4.1.12",
     "@types/express": "^4.17.21",
+    "@types/express-list-endpoints": "^6.0.3",
     "@types/jest": "^29.5.12",
     "@types/morgan": "^1.9.9",
     "@types/node": "^20.11.20",
     "@types/supertest": "^6.0.2",
     "copyfiles": "^2.4.1",
     "eslint-plugin-jest": "^27.9.0",
+    "express-list-endpoints": "^6.0.0",
     "jest": "^29.7.0",
     "jest-mock-extended": "^3.0.5",
     "nodemon": "^3.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "@types/node": "^20.11.20",
     "@types/supertest": "^6.0.2",
     "copyfiles": "^2.4.1",
+    "eslint-plugin-jest": "^27.9.0",
     "jest": "^29.7.0",
     "jest-mock-extended": "^3.0.5",
     "nodemon": "^3.1.0",

--- a/backend/report.json
+++ b/backend/report.json
@@ -1,13 +1,13 @@
 {
-  "numFailedTestSuites": 0,
+  "numFailedTestSuites": 6,
   "numFailedTests": 0,
   "numPassedTestSuites": 0,
   "numPassedTests": 0,
   "numPendingTestSuites": 0,
   "numPendingTests": 0,
-  "numRuntimeErrorTestSuites": 0,
+  "numRuntimeErrorTestSuites": 6,
   "numTodoTests": 0,
-  "numTotalTestSuites": 0,
+  "numTotalTestSuites": 6,
   "numTotalTests": 0,
   "openHandles": [],
   "snapshot": {
@@ -26,8 +26,70 @@
     "unmatched": 0,
     "updated": 0
   },
-  "startTime": 1709184946169,
-  "success": true,
-  "testResults": [],
-  "wasInterrupted": false
+  "startTime": 1709181369487,
+  "success": false,
+  "testResults": [
+    {
+      "assertionResults": [],
+      "coverage": {},
+      "endTime": 1709181393098,
+      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/reminders.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import request from 'supertest';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
+      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/reminders.test.js",
+      "startTime": 1709181393098,
+      "status": "failed",
+      "summary": ""
+    },
+    {
+      "assertionResults": [],
+      "coverage": {},
+      "endTime": 1709181393098,
+      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/babies.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import request from 'supertest';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
+      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/babies.test.js",
+      "startTime": 1709181393098,
+      "status": "failed",
+      "summary": ""
+    },
+    {
+      "assertionResults": [],
+      "coverage": {},
+      "endTime": 1709181393098,
+      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/users.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import request from 'supertest';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
+      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/users.test.js",
+      "startTime": 1709181393098,
+      "status": "failed",
+      "summary": ""
+    },
+    {
+      "assertionResults": [],
+      "coverage": {},
+      "endTime": 1709181393098,
+      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/plans.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import request from 'supertest';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
+      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/plans.test.js",
+      "startTime": 1709181393098,
+      "status": "failed",
+      "summary": ""
+    },
+    {
+      "assertionResults": [],
+      "coverage": {},
+      "endTime": 1709181393098,
+      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/orm/users.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import { prismaMock } from '../mock_client.js';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
+      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/orm/users.test.js",
+      "startTime": 1709181393098,
+      "status": "failed",
+      "summary": ""
+    },
+    {
+      "assertionResults": [],
+      "coverage": {},
+      "endTime": 1709181393098,
+      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/events.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import request from 'supertest';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
+      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/events.test.js",
+      "startTime": 1709181393098,
+      "status": "failed",
+      "summary": ""
+    }
+  ],
+  "wasInterrupted": false,
+  "coverageMap": {}
 }

--- a/backend/report.json
+++ b/backend/report.json
@@ -1,13 +1,13 @@
 {
-  "numFailedTestSuites": 6,
+  "numFailedTestSuites": 0,
   "numFailedTests": 0,
   "numPassedTestSuites": 0,
   "numPassedTests": 0,
   "numPendingTestSuites": 0,
   "numPendingTests": 0,
-  "numRuntimeErrorTestSuites": 6,
+  "numRuntimeErrorTestSuites": 0,
   "numTodoTests": 0,
-  "numTotalTestSuites": 6,
+  "numTotalTestSuites": 0,
   "numTotalTests": 0,
   "openHandles": [],
   "snapshot": {
@@ -26,70 +26,8 @@
     "unmatched": 0,
     "updated": 0
   },
-  "startTime": 1709181369487,
-  "success": false,
-  "testResults": [
-    {
-      "assertionResults": [],
-      "coverage": {},
-      "endTime": 1709181393098,
-      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/reminders.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import request from 'supertest';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
-      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/reminders.test.js",
-      "startTime": 1709181393098,
-      "status": "failed",
-      "summary": ""
-    },
-    {
-      "assertionResults": [],
-      "coverage": {},
-      "endTime": 1709181393098,
-      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/babies.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import request from 'supertest';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
-      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/babies.test.js",
-      "startTime": 1709181393098,
-      "status": "failed",
-      "summary": ""
-    },
-    {
-      "assertionResults": [],
-      "coverage": {},
-      "endTime": 1709181393098,
-      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/users.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import request from 'supertest';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
-      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/users.test.js",
-      "startTime": 1709181393098,
-      "status": "failed",
-      "summary": ""
-    },
-    {
-      "assertionResults": [],
-      "coverage": {},
-      "endTime": 1709181393098,
-      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/plans.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import request from 'supertest';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
-      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/plans.test.js",
-      "startTime": 1709181393098,
-      "status": "failed",
-      "summary": ""
-    },
-    {
-      "assertionResults": [],
-      "coverage": {},
-      "endTime": 1709181393098,
-      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/orm/users.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import { prismaMock } from '../mock_client.js';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
-      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/orm/users.test.js",
-      "startTime": 1709181393098,
-      "status": "failed",
-      "summary": ""
-    },
-    {
-      "assertionResults": [],
-      "coverage": {},
-      "endTime": 1709181393098,
-      "message": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    \u001b[1m\u001b[31mJest encountered an unexpected token\u001b[39m\u001b[22m\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see \u001b[4mhttps://jestjs.io/docs/ecmascript-modules\u001b[24m for how to enable it.\n     • If you are trying to use TypeScript, see \u001b[4mhttps://jestjs.io/docs/getting-started#using-typescript\u001b[24m\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \u001b[1m\"transformIgnorePatterns\"\u001b[22m in your config.\n     • If you need a custom transformation specify a \u001b[1m\"transform\"\u001b[22m option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \u001b[1m\"moduleNameMapper\"\u001b[22m config option.\n\n    You'll find more details and examples of these config options in the docs:\n    \u001b[36mhttps://jestjs.io/docs/configuration\u001b[39m\n    For information about custom transformations, see:\n    \u001b[36mhttps://jestjs.io/docs/code-transformation\u001b[39m\n\n    \u001b[1m\u001b[31mDetails:\u001b[39m\u001b[22m\n\n    /Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/events.test.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import request from 'supertest';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      \u001b[2mat Runtime.createScriptFromCode (\u001b[22m../node_modules/jest-runtime/build/index.js\u001b[2m:1505:14)\u001b[22m\n",
-      "name": "/Users/haruko/Desktop/UIOWA/SEP/Project_Repo/004_SleepTrak/backend/dist/test/api/events.test.js",
-      "startTime": 1709181393098,
-      "status": "failed",
-      "summary": ""
-    }
-  ],
-  "wasInterrupted": false,
-  "coverageMap": {}
+  "startTime": 1709184946169,
+  "success": true,
+  "testResults": [],
+  "wasInterrupted": false
 }

--- a/backend/routes.json
+++ b/backend/routes.json
@@ -1,0 +1,113 @@
+[
+  { "path": "/", "methods": ["GET"], "middlewares": ["anonymous"] },
+  { "path": "/users/all", "methods": ["GET"], "middlewares": ["anonymous"] },
+  { "path": "/users/search", "methods": ["GET"], "middlewares": ["anonymous"] },
+  { "path": "/users/:id", "methods": ["GET"], "middlewares": ["anonymous"] },
+  {
+    "path": "/users/create",
+    "methods": ["POST"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/users/:id/update",
+    "methods": ["PUT"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/users/:id/delete",
+    "methods": ["DELETE"],
+    "middlewares": ["anonymous"]
+  },
+  { "path": "/plans/all", "methods": ["GET"], "middlewares": ["anonymous"] },
+  { "path": "/plans/search", "methods": ["GET"], "middlewares": ["anonymous"] },
+  { "path": "/plans/:id", "methods": ["GET"], "middlewares": ["anonymous"] },
+  {
+    "path": "/plans/create",
+    "methods": ["POST"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/plans/:id/update",
+    "methods": ["PUT"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/plans/:id/delete",
+    "methods": ["DELETE"],
+    "middlewares": ["anonymous"]
+  },
+  { "path": "/events/all", "methods": ["GET"], "middlewares": ["anonymous"] },
+  {
+    "path": "/events/search",
+    "methods": ["GET"],
+    "middlewares": ["anonymous"]
+  },
+  { "path": "/events/:id", "methods": ["GET"], "middlewares": ["anonymous"] },
+  {
+    "path": "/events/create",
+    "methods": ["POST"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/events/:id/update",
+    "methods": ["PUT"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/events/:id/delete",
+    "methods": ["DELETE"],
+    "middlewares": ["anonymous"]
+  },
+  { "path": "/babies/all", "methods": ["GET"], "middlewares": ["anonymous"] },
+  {
+    "path": "/babies/search",
+    "methods": ["GET"],
+    "middlewares": ["anonymous"]
+  },
+  { "path": "/babies/:id", "methods": ["GET"], "middlewares": ["anonymous"] },
+  {
+    "path": "/babies/create",
+    "methods": ["POST"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/babies/:id/update",
+    "methods": ["PUT"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/babies/:id/delete",
+    "methods": ["DELETE"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/reminders/all",
+    "methods": ["GET"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/reminders/search",
+    "methods": ["GET"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/reminders/:id",
+    "methods": ["GET"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/reminders/create",
+    "methods": ["POST"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/reminders/:id/update",
+    "methods": ["PUT"],
+    "middlewares": ["anonymous"]
+  },
+  {
+    "path": "/reminders/:id/delete",
+    "methods": ["DELETE"],
+    "middlewares": ["anonymous"]
+  }
+]

--- a/backend/src/controllers/babies.ts
+++ b/backend/src/controllers/babies.ts
@@ -34,7 +34,7 @@ const create = async (req: Request, res: Response): Promise<void> => {
 
     const babyData = {
       name: creationParams.name,
-      dob: new Date(creationParams.dob),
+      dob: creationParams.dob ? new Date(creationParams.dob) : null,
       weight: creationParams.weight,
       medicine: creationParams.medicine,
       parent: { connect: { userId: creationParams.parentId } }

--- a/backend/src/controllers/events.ts
+++ b/backend/src/controllers/events.ts
@@ -34,8 +34,10 @@ const create = async (req: Request, res: Response): Promise<void> => {
 
     const eventData = {
       owner: { connect: { userId: creationParams.ownerId } },
-      startTime: new Date(creationParams.startTime),
-      endTime: new Date(creationParams.endTime),
+      startTime: creationParams.startTime
+        ? new Date(creationParams.startTime)
+        : null,
+      endTime: creationParams.endTime ? new Date(creationParams.endTime) : null,
       type: creationParams.type
     };
 

--- a/backend/src/controllers/reminders.ts
+++ b/backend/src/controllers/reminders.ts
@@ -34,7 +34,9 @@ const create = async (req: Request, res: Response): Promise<void> => {
 
     const reminderData = {
       plan: { connect: { planId: creationParams.planId } },
-      timestamp: new Date(creationParams.timestamp),
+      timestamp: creationParams.timestamp
+        ? new Date(creationParams.timestamp)
+        : null,
       description: creationParams.description
     };
 

--- a/backend/test/api/babies.test.ts
+++ b/backend/test/api/babies.test.ts
@@ -1,3 +1,4 @@
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { testRoute } from './common.js';
 
 const mockBabys = [
@@ -26,6 +27,9 @@ const baby = {
   weight: 8,
   medicine: 'pencillin'
 };
+
+// Happy Path Tests
+// ============================================================================
 
 // /babys/all
 testRoute({
@@ -141,6 +145,279 @@ testRoute({
   expectData: {
     status: 200,
     body: baby,
+    calledWith: {
+      where: {
+        babyId: ':id'
+      }
+    }
+  },
+  model: 'baby',
+  id: '1',
+  route: 'delete'
+});
+
+// Sad Path Tests
+// ============================================================================
+
+// /babys/all
+testRoute({
+  description: 'returns no babys if there are none',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      include: {
+        parent: true
+      }
+    }
+  },
+  model: 'baby',
+  route: 'all'
+});
+
+// /babys/:id
+testRoute({
+  description: 'returns nothing if no baby matches :id',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      include: {
+        parent: true
+      },
+      where: {
+        babyId: ':id'
+      }
+    }
+  },
+  model: 'baby',
+  id: '5'
+});
+
+// /babys/search
+testRoute({
+  description: 'returns nothing if no babys match searched weight',
+  reqData: {
+    weight: 100
+  },
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        weight: 100
+      }
+    }
+  },
+  model: 'baby',
+  route: 'search'
+});
+
+// /babys/create
+testRoute({
+  description: 'returns empty object when no data passed',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      data: {
+        parent: { connect: { userId: undefined } },
+        name: undefined,
+        dob: null,
+        weight: undefined,
+        medicine: undefined
+      }
+    }
+  },
+  model: 'baby',
+  route: 'create'
+});
+
+// /babys/update
+testRoute({
+  description: 'returns unupdated baby if no data passed',
+  reqData: {},
+  mockData: baby,
+  expectData: {
+    status: 200,
+    body: baby,
+    calledWith: {
+      data: {},
+      where: {
+        babyId: ':id'
+      }
+    }
+  },
+  model: 'baby',
+  id: '1',
+  route: 'update'
+});
+
+// /babys/delete
+testRoute({
+  description: 'returns nothing if no baby matches :id',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        babyId: ':id'
+      }
+    }
+  },
+  model: 'baby',
+  id: '5',
+  route: 'delete'
+});
+
+// Error Path Tests
+// ============================================================================
+
+const prismaError = new PrismaClientKnownRequestError(
+  'Error manually generated for testing',
+  {
+    code: 'P2010',
+    clientVersion: 'jest mock'
+  }
+);
+// /babys/all
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      include: {
+        parent: true
+      }
+    }
+  },
+  model: 'baby',
+  route: 'all'
+});
+
+// /babys/:id
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      include: {
+        parent: true
+      },
+      where: {
+        babyId: ':id'
+      }
+    }
+  },
+  model: 'baby',
+  id: '1'
+});
+
+// /babys/search
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      where: {}
+    }
+  },
+  model: 'baby',
+  route: 'search'
+});
+
+// /babys/create
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      data: {
+        parent: { connect: { userId: undefined } },
+        name: undefined,
+        dob: null,
+        weight: undefined,
+        medicine: undefined
+      }
+    }
+  },
+  model: 'baby',
+  route: 'create'
+});
+
+// /babys/update
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      data: {},
+      where: {
+        babyId: ':id'
+      }
+    }
+  },
+  model: 'baby',
+  id: '1',
+  route: 'update'
+});
+
+// /babys/delete
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
     calledWith: {
       where: {
         babyId: ':id'

--- a/backend/test/api/babies.test.ts
+++ b/backend/test/api/babies.test.ts
@@ -34,7 +34,12 @@ testRoute({
   mockData: mockBabys,
   expectData: {
     status: 200,
-    body: mockBabys
+    body: mockBabys,
+    calledWith: {
+      include: {
+        parent: true
+      }
+    }
   },
   model: 'baby',
   route: 'all'
@@ -49,6 +54,9 @@ testRoute({
     status: 200,
     body: mockBabys.filter((baby) => baby.babyId === '1'),
     calledWith: {
+      include: {
+        parent: true
+      },
       where: {
         babyId: ':id'
       }

--- a/backend/test/api/babies.test.ts
+++ b/backend/test/api/babies.test.ts
@@ -29,6 +29,7 @@ const baby = {
 
 // /babys/all
 testRoute({
+  description: 'returns all babies',
   reqData: {},
   mockData: mockBabys,
   expectData: {
@@ -41,6 +42,7 @@ testRoute({
 
 // /babys/:id
 testRoute({
+  description: 'returns baby matching :id',
   reqData: {},
   mockData: mockBabys.filter((baby) => baby.babyId === '1'),
   expectData: {
@@ -58,6 +60,7 @@ testRoute({
 
 // /babys/search
 testRoute({
+  description: 'returns babies matching search by medicine',
   reqData: {
     role: 'client'
   },
@@ -78,6 +81,7 @@ testRoute({
 // /babys/create
 const { babyId: _b, parentId: _p, ...babyProps } = baby;
 testRoute({
+  description: 'returns created baby',
   reqData: {
     ...baby
   },
@@ -99,6 +103,7 @@ testRoute({
 
 // /babys/update
 testRoute({
+  description: 'returns updated baby',
   reqData: {
     ...baby
   },
@@ -122,6 +127,7 @@ testRoute({
 
 // /babys/delete
 testRoute({
+  description: 'returns deleted baby',
   reqData: {},
   mockData: baby,
   expectData: {

--- a/backend/test/api/common.ts
+++ b/backend/test/api/common.ts
@@ -18,6 +18,7 @@ jest.unstable_mockModule('../../src/services/auth.js', () => ({
 const app = (await import('../../src/app.js')).default;
 
 export interface testRouteParams {
+  description: string;
   reqData: object;
   mockData: object;
   expectData: {
@@ -65,6 +66,7 @@ function generateURL(controller: string, id?: string, route?: string): string {
 
 // model should be the singular form
 export function testRoute({
+  description,
   reqData,
   mockData,
   expectData,
@@ -74,8 +76,8 @@ export function testRoute({
 }: testRouteParams): void {
   const controller = generateController(model);
   const url = generateURL(controller, id, route);
-  describe(`Test ${url} route`, () => {
-    test(`GET ${url} returns as expected`, async () => {
+  describe(`Test ${url} route, controller, service, bypassing oauth & prisma`, () => {
+    test(`GET ${url} ${description}`, async () => {
       if (!route) {
         route = 'get';
       }

--- a/backend/test/api/common.ts
+++ b/backend/test/api/common.ts
@@ -81,7 +81,11 @@ export function testRoute({
       if (!route) {
         route = 'get';
       }
-      prismaSpy[controller][route].mockResolvedValue(mockData);
+      if (mockData instanceof Error) {
+        prismaSpy[controller][route].mockRejectedValue(mockData);
+      } else {
+        prismaSpy[controller][route].mockResolvedValue(mockData);
+      }
 
       const httpMethod = generateHTTPMethod(route);
       const response = await request(app)[httpMethod](url).send(reqData);

--- a/backend/test/api/events.test.ts
+++ b/backend/test/api/events.test.ts
@@ -26,6 +26,7 @@ const event = {
 
 // /events/all
 testRoute({
+  description: 'returns all events',
   reqData: {},
   mockData: mockEvents,
   expectData: {
@@ -38,6 +39,7 @@ testRoute({
 
 // /events/:id
 testRoute({
+  description: 'returns event matching :id',
   reqData: {},
   mockData: mockEvents.filter((event) => event.eventId === '1'),
   expectData: {
@@ -55,6 +57,7 @@ testRoute({
 
 // /events/search
 testRoute({
+  description: 'returns events matching search by type',
   reqData: {
     role: 'client'
   },
@@ -75,6 +78,7 @@ testRoute({
 // /events/create
 const { eventId: _e, ownerId: _o, ...eventProps } = event;
 testRoute({
+  description: 'returns created event',
   reqData: {
     ...event
   },
@@ -97,6 +101,7 @@ testRoute({
 
 // /events/update
 testRoute({
+  description: 'returns updated event',
   reqData: {
     ...event
   },
@@ -120,6 +125,7 @@ testRoute({
 
 // /events/delete
 testRoute({
+  description: 'returns deleted event',
   reqData: {},
   mockData: event,
   expectData: {

--- a/backend/test/api/events.test.ts
+++ b/backend/test/api/events.test.ts
@@ -1,3 +1,4 @@
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { testRoute } from './common.js';
 
 const mockEvents = [
@@ -23,6 +24,9 @@ const event = {
   endTime: '2024-01-01T13:00:00Z',
   type: 'wake'
 };
+
+// Happy Path Tests
+// ============================================================================
 
 // /events/all
 testRoute({
@@ -131,6 +135,261 @@ testRoute({
   expectData: {
     status: 200,
     body: event,
+    calledWith: {
+      where: {
+        eventId: ':id'
+      }
+    }
+  },
+  model: 'event',
+  id: '1',
+  route: 'delete'
+});
+
+// Sad Path Tests
+// ============================================================================
+
+// /events/all
+testRoute({
+  description: 'returns no events if there are none',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {}
+  },
+  model: 'event',
+  route: 'all'
+});
+
+// /events/:id
+testRoute({
+  description: 'returns nothing if no event matches :id',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        eventId: ':id'
+      }
+    }
+  },
+  model: 'event',
+  id: '5'
+});
+
+// /events/search
+testRoute({
+  description: 'returns nothing if no events match searched role',
+  reqData: {
+    type: 'nap'
+  },
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        type: 'nap'
+      }
+    }
+  },
+  model: 'event',
+  route: 'search'
+});
+
+// /events/create
+testRoute({
+  description: 'returns empty object when no data passed',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      data: {
+        owner: { connect: { userId: undefined } },
+        startTime: null,
+        endTime: null,
+        type: undefined
+      }
+    }
+  },
+  model: 'event',
+  route: 'create'
+});
+
+// /events/update
+testRoute({
+  description: 'returns unupdated event if no data passed',
+  reqData: {},
+  mockData: event,
+  expectData: {
+    status: 200,
+    body: event,
+    calledWith: {
+      data: {},
+      where: {
+        eventId: ':id'
+      }
+    }
+  },
+  model: 'event',
+  id: '1',
+  route: 'update'
+});
+
+// /events/delete
+testRoute({
+  description: 'returns nothing if no event matches :id',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        eventId: ':id'
+      }
+    }
+  },
+  model: 'event',
+  id: '5',
+  route: 'delete'
+});
+
+// Error Path Tests
+// ============================================================================
+
+const prismaError = new PrismaClientKnownRequestError(
+  'Error manually generated for testing',
+  {
+    code: 'P2010',
+    clientVersion: 'jest mock'
+  }
+);
+// /events/all
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    }
+  },
+  model: 'event',
+  route: 'all'
+});
+
+// /events/:id
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      where: {
+        eventId: ':id'
+      }
+    }
+  },
+  model: 'event',
+  id: '1'
+});
+
+// /events/search
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      where: {}
+    }
+  },
+  model: 'event',
+  route: 'search'
+});
+
+// /events/create
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      data: {
+        owner: { connect: { userId: undefined } },
+        startTime: null,
+        endTime: null,
+        type: undefined
+      }
+    }
+  },
+  model: 'event',
+  route: 'create'
+});
+
+// /events/update
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      data: {},
+      where: {
+        eventId: ':id'
+      }
+    }
+  },
+  model: 'event',
+  id: '1',
+  route: 'update'
+});
+
+// /events/delete
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
     calledWith: {
       where: {
         eventId: ':id'

--- a/backend/test/api/plans.test.ts
+++ b/backend/test/api/plans.test.ts
@@ -24,6 +24,7 @@ const plan = {
 
 // /plans/all
 testRoute({
+  description: 'returns all plans',
   reqData: {},
   mockData: mockPlans,
   expectData: {
@@ -36,6 +37,7 @@ testRoute({
 
 // /plans/:id
 testRoute({
+  description: 'returns plan matching :id',
   reqData: {},
   mockData: mockPlans.filter((plan) => plan.planId === '1'),
   expectData: {
@@ -53,6 +55,7 @@ testRoute({
 
 // /plans/search
 testRoute({
+  description: 'returns plans matching search by Status',
   reqData: {
     Status: 'complete'
   },
@@ -73,6 +76,7 @@ testRoute({
 // /plans/create
 const { planId: _p, clientId: _cl, coachId: _co, ...planProps } = plan;
 testRoute({
+  description: 'returns created plan',
   reqData: {
     ...plan
   },
@@ -94,6 +98,7 @@ testRoute({
 
 // /plans/update
 testRoute({
+  description: 'returns updated  plan',
   reqData: {
     ...plan
   },
@@ -117,6 +122,7 @@ testRoute({
 
 // /plans/delete
 testRoute({
+  description: 'returns deleted plan',
   reqData: {},
   mockData: plan,
   expectData: {

--- a/backend/test/api/plans.test.ts
+++ b/backend/test/api/plans.test.ts
@@ -1,3 +1,4 @@
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { testRoute } from './common.js';
 import type { Plan } from '@prisma/client';
 
@@ -22,6 +23,8 @@ const plan = {
   Status: 'cancelled'
 };
 
+// Happy Path Tests
+// ============================================================================
 // /plans/all
 testRoute({
   description: 'returns all plans',
@@ -128,6 +131,259 @@ testRoute({
   expectData: {
     status: 200,
     body: plan,
+    calledWith: {
+      where: {
+        planId: ':id'
+      }
+    }
+  },
+  model: 'plan',
+  id: '1',
+  route: 'delete'
+});
+
+// Sad Path Tests
+// ============================================================================
+
+// /plans/all
+testRoute({
+  description: 'returns no plans if there are none',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {}
+  },
+  model: 'plan',
+  route: 'all'
+});
+
+// /plans/:id
+testRoute({
+  description: 'returns nothing if no plan matches :id',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        planId: ':id'
+      }
+    }
+  },
+  model: 'plan',
+  id: '5'
+});
+
+// /plans/search
+testRoute({
+  description: 'returns nothing if no plans match searched role',
+  reqData: {
+    Status: 'complete'
+  },
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        Status: 'complete'
+      }
+    }
+  },
+  model: 'plan',
+  route: 'search'
+});
+
+// /plans/create
+testRoute({
+  description: 'returns empty object when no data passed',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      data: {
+        client: { connect: { userId: undefined } },
+        coach: { connect: { coachId: undefined } },
+        Status: undefined
+      }
+    }
+  },
+  model: 'plan',
+  route: 'create'
+});
+
+// /plans/update
+testRoute({
+  description: 'returns unupdated plan if no data passed',
+  reqData: {},
+  mockData: plan,
+  expectData: {
+    status: 200,
+    body: plan,
+    calledWith: {
+      data: {},
+      where: {
+        planId: ':id'
+      }
+    }
+  },
+  model: 'plan',
+  id: '1',
+  route: 'update'
+});
+
+// /plans/delete
+testRoute({
+  description: 'returns nothing if no plan matches :id',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        planId: ':id'
+      }
+    }
+  },
+  model: 'plan',
+  id: '5',
+  route: 'delete'
+});
+
+// Error Path Tests
+// ============================================================================
+
+const prismaError = new PrismaClientKnownRequestError(
+  'Error manually generated for testing',
+  {
+    code: 'P2010',
+    clientVersion: 'jest mock'
+  }
+);
+// /plans/all
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    }
+  },
+  model: 'plan',
+  route: 'all'
+});
+
+// /plans/:id
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      where: {
+        planId: ':id'
+      }
+    }
+  },
+  model: 'plan',
+  id: '1'
+});
+
+// /plans/search
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      where: {}
+    }
+  },
+  model: 'plan',
+  route: 'search'
+});
+
+// /plans/create
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      data: {
+        client: { connect: { userId: undefined } },
+        coach: { connect: { userId: undefined } },
+        Status: undefined
+      }
+    }
+  },
+  model: 'plan',
+  route: 'create'
+});
+
+// /plans/update
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      data: {},
+      where: {
+        planId: ':id'
+      }
+    }
+  },
+  model: 'plan',
+  id: '1',
+  route: 'update'
+});
+
+// /plans/delete
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
     calledWith: {
       where: {
         planId: ':id'

--- a/backend/test/api/reminders.test.ts
+++ b/backend/test/api/reminders.test.ts
@@ -23,6 +23,7 @@ const reminder = {
 
 // /reminders/all
 testRoute({
+  description: 'returns all reminders',
   reqData: {},
   mockData: mockReminders,
   expectData: {
@@ -35,6 +36,7 @@ testRoute({
 
 // /reminders/:id
 testRoute({
+  description: 'returns reminder matching :id',
   reqData: {},
   mockData: mockReminders.filter((reminder) => reminder.reminderId === '1'),
   expectData: {
@@ -52,6 +54,7 @@ testRoute({
 
 // /reminders/search
 testRoute({
+  description: 'returns reminders matching search by description',
   reqData: {
     role: 'client'
   },
@@ -72,6 +75,7 @@ testRoute({
 // /reminders/create
 const { reminderId: _u, planId: _p, ...reminderProps } = reminder;
 testRoute({
+  description: 'returns created reminder',
   reqData: {
     ...reminder
   },
@@ -93,6 +97,7 @@ testRoute({
 
 // /reminders/update
 testRoute({
+  description: 'returns updated reminder',
   reqData: {
     ...reminder
   },
@@ -116,6 +121,7 @@ testRoute({
 
 // /reminders/delete
 testRoute({
+  description: 'returns deleted reminder',
   reqData: {},
   mockData: reminder,
   expectData: {

--- a/backend/test/api/reminders.test.ts
+++ b/backend/test/api/reminders.test.ts
@@ -1,3 +1,4 @@
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { testRoute } from './common.js';
 
 const mockReminders = [
@@ -20,6 +21,9 @@ const reminder = {
   description: 'nap',
   timestamp: '2024-01-01T12:00:00Z'
 };
+
+// Happy Path Tests
+// ============================================================================
 
 // /reminders/all
 testRoute({
@@ -127,6 +131,259 @@ testRoute({
   expectData: {
     status: 200,
     body: reminder,
+    calledWith: {
+      where: {
+        reminderId: ':id'
+      }
+    }
+  },
+  model: 'reminder',
+  id: '1',
+  route: 'delete'
+});
+
+// Sad Path Tests
+// ============================================================================
+
+// /reminders/all
+testRoute({
+  description: 'returns no reminders if there are none',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {}
+  },
+  model: 'reminder',
+  route: 'all'
+});
+
+// /reminders/:id
+testRoute({
+  description: 'returns nothing if no reminder matches :id',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        reminderId: ':id'
+      }
+    }
+  },
+  model: 'reminder',
+  id: '5'
+});
+
+// /reminders/search
+testRoute({
+  description: 'returns nothing if no reminders match searched role',
+  reqData: {
+    description: 'nap'
+  },
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        description: 'nap'
+      }
+    }
+  },
+  model: 'reminder',
+  route: 'search'
+});
+
+// /reminders/create
+testRoute({
+  description: 'returns empty object when no data passed',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      data: {
+        plan: { connect: { planId: undefined } },
+        description: undefined,
+        timestamp: null
+      }
+    }
+  },
+  model: 'reminder',
+  route: 'create'
+});
+
+// /reminders/update
+testRoute({
+  description: 'returns unupdated reminder if no data passed',
+  reqData: {},
+  mockData: reminder,
+  expectData: {
+    status: 200,
+    body: reminder,
+    calledWith: {
+      data: {},
+      where: {
+        reminderId: ':id'
+      }
+    }
+  },
+  model: 'reminder',
+  id: '1',
+  route: 'update'
+});
+
+// /reminders/delete
+testRoute({
+  description: 'returns nothing if no reminder matches :id',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        reminderId: ':id'
+      }
+    }
+  },
+  model: 'reminder',
+  id: '5',
+  route: 'delete'
+});
+
+// Error Path Tests
+// ============================================================================
+
+const prismaError = new PrismaClientKnownRequestError(
+  'Error manually generated for testing',
+  {
+    code: 'P2010',
+    clientVersion: 'jest mock'
+  }
+);
+// /reminders/all
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    }
+  },
+  model: 'reminder',
+  route: 'all'
+});
+
+// /reminders/:id
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      where: {
+        reminderId: ':id'
+      }
+    }
+  },
+  model: 'reminder',
+  id: '1'
+});
+
+// /reminders/search
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      where: {}
+    }
+  },
+  model: 'reminder',
+  route: 'search'
+});
+
+// /reminders/create
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      data: {
+        plan: { connect: { planId: undefined } },
+        description: undefined,
+        timestamp: null
+      }
+    }
+  },
+  model: 'reminder',
+  route: 'create'
+});
+
+// /reminders/update
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      data: {},
+      where: {
+        reminderId: ':id'
+      }
+    }
+  },
+  model: 'reminder',
+  id: '1',
+  route: 'update'
+});
+
+// /reminders/delete
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
     calledWith: {
       where: {
         reminderId: ':id'

--- a/backend/test/api/users.test.ts
+++ b/backend/test/api/users.test.ts
@@ -1,3 +1,4 @@
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { testRoute } from './common.js';
 import type { User } from '@prisma/client';
 
@@ -154,6 +155,7 @@ testRoute({
   id: '1',
   route: 'delete'
 });
+
 // Sad Path Tests
 // ============================================================================
 
@@ -273,5 +275,154 @@ testRoute({
   },
   model: 'user',
   id: '5',
+  route: 'delete'
+});
+
+// Error Path Tests
+// ============================================================================
+
+const prismaError = new PrismaClientKnownRequestError(
+  'Error manually generated for testing',
+  {
+    code: 'P2010',
+    clientVersion: 'jest mock'
+  }
+);
+// /users/all
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      include: {
+        Babies: true
+      }
+    }
+  },
+  model: 'user',
+  route: 'all'
+});
+
+// /users/:id
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      include: {
+        Babies: true
+      },
+      where: {
+        userId: ':id'
+      }
+    }
+  },
+  model: 'user',
+  id: '1'
+});
+
+// /users/search
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      where: {}
+    }
+  },
+  model: 'user',
+  route: 'search'
+});
+
+// /users/create
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      data: {
+        first_name: undefined,
+        last_name: undefined,
+        email: undefined,
+        role: undefined
+      }
+    }
+  },
+  model: 'user',
+  route: 'create'
+});
+
+// /users/update
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      data: {},
+      where: {
+        userId: ':id'
+      }
+    }
+  },
+  model: 'user',
+  id: '1',
+  route: 'update'
+});
+
+// /users/delete
+testRoute({
+  description: 'returns HTTP 500 if Prisma throws error',
+  reqData: {},
+  mockData: prismaError,
+  expectData: {
+    status: 500,
+    body: {
+      name: prismaError.name,
+      code: prismaError.code,
+      clientVersion: prismaError.clientVersion
+    },
+    calledWith: {
+      where: {
+        userId: ':id'
+      }
+    }
+  },
+  model: 'user',
+  id: '1',
   route: 'delete'
 });

--- a/backend/test/api/users.test.ts
+++ b/backend/test/api/users.test.ts
@@ -30,6 +30,7 @@ const user = {
 
 // /users/all
 testRoute({
+  description: 'returns all users',
   reqData: {},
   mockData: mockUsers,
   expectData: {
@@ -42,6 +43,7 @@ testRoute({
 
 // /users/:id
 testRoute({
+  description: 'returns user matching :id',
   reqData: {},
   mockData: mockUsers.filter((user) => user.userId === '1'),
   expectData: {
@@ -59,6 +61,7 @@ testRoute({
 
 // /users/search
 testRoute({
+  description: 'returns user matching search by role',
   reqData: {
     role: 'client'
   },
@@ -79,6 +82,7 @@ testRoute({
 // /users/create
 const { userId: _u, coachId: _c, ...userProps } = user;
 testRoute({
+  description: 'returns created user',
   reqData: {
     ...user
   },
@@ -99,6 +103,7 @@ testRoute({
 
 // /users/update
 testRoute({
+  description: 'returns updated user',
   reqData: {
     ...user
   },
@@ -122,6 +127,7 @@ testRoute({
 
 // /users/delete
 testRoute({
+  description: 'returns deleted user',
   reqData: {},
   mockData: user,
   expectData: {

--- a/backend/test/api/users.test.ts
+++ b/backend/test/api/users.test.ts
@@ -38,7 +38,12 @@ testRoute({
   mockData: mockUsers,
   expectData: {
     status: 200,
-    body: mockUsers
+    body: mockUsers,
+    calledWith: {
+      include: {
+        Babies: true
+      }
+    }
   },
   model: 'user',
   route: 'all'
@@ -53,6 +58,9 @@ testRoute({
     status: 200,
     body: mockUsers.filter((user) => user.userId === '1'),
     calledWith: {
+      include: {
+        Babies: true
+      },
       where: {
         userId: ':id'
       }
@@ -156,7 +164,12 @@ testRoute({
   mockData: {},
   expectData: {
     status: 200,
-    body: {}
+    body: {},
+    calledWith: {
+      include: {
+        Babies: true
+      }
+    }
   },
   model: 'user',
   route: 'all'
@@ -171,6 +184,9 @@ testRoute({
     status: 200,
     body: {},
     calledWith: {
+      include: {
+        Babies: true
+      },
       where: {
         userId: ':id'
       }

--- a/backend/test/api/users.test.ts
+++ b/backend/test/api/users.test.ts
@@ -28,6 +28,9 @@ const user = {
   role: 'client'
 };
 
+// Happy Path Tests
+// ============================================================================
+
 // /users/all
 testRoute({
   description: 'returns all users',
@@ -141,5 +144,118 @@ testRoute({
   },
   model: 'user',
   id: '1',
+  route: 'delete'
+});
+// Sad Path Tests
+// ============================================================================
+
+// /users/all
+testRoute({
+  description: 'returns no users if there are none',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {}
+  },
+  model: 'user',
+  route: 'all'
+});
+
+// /users/:id
+testRoute({
+  description: 'returns nothing if no user matches :id',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        userId: ':id'
+      }
+    }
+  },
+  model: 'user',
+  id: '5'
+});
+
+// /users/search
+testRoute({
+  description: 'returns nothing if no users match searched role',
+  reqData: {
+    role: 'admin'
+  },
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        role: 'admin'
+      }
+    }
+  },
+  model: 'user',
+  route: 'search'
+});
+
+// /users/create
+testRoute({
+  description: 'returns empty object when no data passed',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      data: {
+        first_name: undefined,
+        last_name: undefined,
+        email: undefined,
+        role: undefined
+      }
+    }
+  },
+  model: 'user',
+  route: 'create'
+});
+
+// /users/update
+testRoute({
+  description: 'returns unupdated user if no data passed',
+  reqData: {},
+  mockData: user,
+  expectData: {
+    status: 200,
+    body: user,
+    calledWith: {
+      data: {},
+      where: {
+        userId: ':id'
+      }
+    }
+  },
+  model: 'user',
+  id: '1',
+  route: 'update'
+});
+
+// /users/delete
+testRoute({
+  description: 'returns nothing if no user matches :id',
+  reqData: {},
+  mockData: {},
+  expectData: {
+    status: 200,
+    body: {},
+    calledWith: {
+      where: {
+        userId: ':id'
+      }
+    }
+  },
+  model: 'user',
+  id: '5',
   route: 'delete'
 });

--- a/backend/test/list-routes.ts
+++ b/backend/test/list-routes.ts
@@ -1,0 +1,11 @@
+import expressListEndpoints from 'express-list-endpoints';
+import { writeFile } from 'fs/promises';
+import app from '../src/app.js';
+
+const endpoints = expressListEndpoints(app);
+
+async function writeToFile(): Promise<void> {
+  await writeFile('routes.json', JSON.stringify(endpoints));
+}
+
+writeToFile().catch(console.error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5597,6 +5597,13 @@ eslint-plugin-jest@^27.8.0:
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
+eslint-plugin-jest@^27.9.0:
+  version "27.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz#7c98a33605e1d8b8442ace092b60e9919730000b"
+  integrity sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==
+  dependencies:
+    "@typescript-eslint/utils" "^5.10.0"
+
 eslint-plugin-n@^16.6.2:
   version "16.6.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-n/-/eslint-plugin-n-16.6.2.tgz#6a60a1a376870064c906742272074d5d0b412b0b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3084,6 +3084,13 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
+"@types/express-list-endpoints@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@types/express-list-endpoints/-/express-list-endpoints-6.0.3.tgz#6be51cea8b244cd3d179c367a15f67a333025575"
+  integrity sha512-0lZ5pOHtivd8Vx49E5gBQHMTmccMCQTLGjPBsBKHABdC9b55VY86dxvhfMkbJefzaH0YHhgExWOg5WoG2gDIeg==
+  dependencies:
+    "@types/express" "*"
+
 "@types/express-serve-static-core@^4.17.33":
   version "4.17.43"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz#10d8444be560cb789c4735aea5eac6e5af45df54"
@@ -3094,7 +3101,7 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@^4.17.21":
+"@types/express@*", "@types/express@^4.17.21":
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
   integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
@@ -5918,6 +5925,11 @@ expo@~50.0.8:
     expo-modules-core "1.11.9"
     fbemitter "^3.0.0"
     whatwg-url-without-unicode "8.0.0-3"
+
+express-list-endpoints@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/express-list-endpoints/-/express-list-endpoints-6.0.0.tgz#903f000b0cc954bbc35ca44e7aa3917e5292d0c2"
+  integrity sha512-1I30bSVego+AU/eSsX/bV2xrOXW5tFhsuXZp7wZd9396bAAxH7KHaAwLXQYra0Aw33xA67HmNiceGf2SOvXaLg==
 
 express-oauth2-jwt-bearer@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
## Describe your changes
Adds unit testing for the sad paths and error handling paths of our backend API using the prismaSpy infrastructure.  We now have 100% coverage of API controllers and services.

## JIRA Ticket Link
https://septeam4.atlassian.net/browse/T4-47

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Is the code correctly formatted?
- [ ] If this is a feature, is there a related Notion document for the feature?
![image](https://github.com/uiowaSEP2024/004_SleepTrak/assets/71203230/7087d198-4112-4248-9537-df5eab11e0b0)
