### PR TITLE
Refactor: Prisma Types in Frontend

### DIFF
--- a/web/src/__tests__/components/BabyDropdown.test.tsx
+++ b/web/src/__tests__/components/BabyDropdown.test.tsx
@@ -3,6 +3,7 @@ import '../../util/setupDomTests';
 import { fireEvent, render } from '@testing-library/react';
 import BabyDropdown from '../../components/BabyDropdown';
 import { BrowserRouter, useNavigate } from 'react-router-dom';
+import { Baby } from '@prisma/client';
 
 // Mock navigate and useNavigate from react-router-dom
 jest.mock('react-router-dom', () => ({
@@ -15,24 +16,30 @@ const navigateMock: jest.Mock = jest.fn();
 (useNavigate as jest.Mock).mockImplementation(() => navigateMock);
 
 describe('BabyDropdown component', () => {
-  const babies = [
+  const babies: Baby[] = [
     {
-      dob: '2023-01-15',
+      dob: new Date('2023-01-15'),
       babyId: '1',
       name: 'Baby 1',
-      parentId: '101'
+      parentId: '101',
+      weight: 8,
+      medicine: ''
     },
     {
-      dob: '2023-05-20',
+      dob: new Date('2023-05-20'),
       babyId: '2',
       name: 'Baby 2',
-      parentId: '101'
+      parentId: '101',
+      weight: 8,
+      medicine: ''
     },
     {
-      dob: '2023-09-10',
+      dob: new Date('2023-09-10'),
       babyId: '3',
       name: 'Baby 3',
-      parentId: '102'
+      parentId: '102',
+      weight: 8,
+      medicine: ''
     }
   ];
 

--- a/web/src/__tests__/components/RecommendedSchedule/RecommendedSchedule.test.tsx
+++ b/web/src/__tests__/components/RecommendedSchedule/RecommendedSchedule.test.tsx
@@ -20,36 +20,37 @@ jest.mock(
 );
 
 describe('RecommendedSchedule', () => {
-  const sampleSchedule: PlanWithReminders = {
+  const samplePlan: PlanWithReminders = {
+    planId: 'sample-plan-id',
+    clientId: 'sample-client-id',
+    coachId: 'sample-coach-id',
+    reminders: [
+      {
+        reminderId: '1',
+        planId: 'sample-plan-id',
+        description: 'Morning Rise',
+        startTime: new Date('2024-04-08T06:30:00+0000'),
+        endTime: null
+      },
+      {
+        reminderId: '2',
+        planId: 'sample-plan-id',
+        description: 'Nap 1',
+        startTime: new Date('2024-04-08T09:45:00+0000'),
+        endTime: new Date('2024-04-08T10:45:00+0000')
+      },
+      {
+        reminderId: '3',
+        planId: 'sample-plan-id',
+        description: 'Asleep',
+        startTime: new Date('2024-04-08T20:00:00+0000'),
+        endTime: null
+      }
+    ]
+  };
+  const sampleSchedule = {
     name: 'Schedule 1',
-    schedule: {
-      planId: 'sample-plan-id',
-      clientId: 'sample-client-id',
-      coachId: 'sample-coach-id',
-      reminders: [
-        {
-          reminderId: '1',
-          planId: 'sample-plan-id',
-          description: 'Morning Rise',
-          startTime: new Date('2024-04-08T06:30:00+0000'),
-          endTime: null
-        },
-        {
-          reminderId: '2',
-          planId: 'sample-plan-id',
-          description: 'Nap 1',
-          startTime: '09:15',
-          endTime: new Date('2024-04-08T10:45:00+0000')
-        },
-        {
-          reminderId: '3',
-          planId: 'sample-plan-id',
-          description: 'Asleep',
-          startTime: new Date('2024-04-08T20:00:00+0000'),
-          endTime: null
-        }
-      ]
-    },
+    schedule: samplePlan,
     onChange: jest.fn() // Mocked onChange function
   };
 

--- a/web/src/__tests__/components/RecommendedSchedule/RecommendedSchedule.test.tsx
+++ b/web/src/__tests__/components/RecommendedSchedule/RecommendedSchedule.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import '../../../util/setupDomTests';
 import { render, screen } from '@testing-library/react';
 import RecommendedSchedule from '../../../components/RecommendedSchedule/RecommendedSchedule';
+import { PlanWithReminders } from '../../../types/schemaExtensions';
 
 // Mock ScheduleCreateButton, ScheduleDeleteButton, ScheduleEditRowButton, and ScheduleDeleteRowButton
 
@@ -19,7 +20,7 @@ jest.mock(
 );
 
 describe('RecommendedSchedule', () => {
-  const sampleSchedule = {
+  const sampleSchedule: PlanWithReminders = {
     name: 'Schedule 1',
     schedule: {
       planId: 'sample-plan-id',
@@ -30,7 +31,7 @@ describe('RecommendedSchedule', () => {
           reminderId: '1',
           planId: 'sample-plan-id',
           description: 'Morning Rise',
-          startTime: '06:30',
+          startTime: new Date('2024-04-08T06:30:00+0000'),
           endTime: null
         },
         {
@@ -38,13 +39,13 @@ describe('RecommendedSchedule', () => {
           planId: 'sample-plan-id',
           description: 'Nap 1',
           startTime: '09:15',
-          endTime: '10:45'
+          endTime: new Date('2024-04-08T10:45:00+0000')
         },
         {
           reminderId: '3',
           planId: 'sample-plan-id',
           description: 'Asleep',
-          startTime: '20:00',
+          startTime: new Date('2024-04-08T20:00:00+0000'),
           endTime: null
         }
       ]

--- a/web/src/__tests__/components/RecommendedSchedule/ScheduleDeleteButton.test.tsx
+++ b/web/src/__tests__/components/RecommendedSchedule/ScheduleDeleteButton.test.tsx
@@ -2,21 +2,12 @@ import '@testing-library/jest-dom';
 import '../../../util/setupDomTests';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import ScheduleDeleteButton from '../../../components/RecommendedSchedule/ScheduleDeleteButton';
-import { Plan } from '../../../components/RecommendedSchedule/RecommendedSchedule';
 
-const mockPlan: Plan = {
+const mockPlan = {
   planId: '1',
   clientId: '1',
   coachId: '1',
-  reminders: [
-    {
-      reminderId: '1',
-      planId: '1',
-      description: 'Reminder 1',
-      startTime: '2024-02-27T08:00:00.000Z',
-      endTime: '2024-02-27T08:30:00.000Z'
-    }
-  ]
+  reminders: []
 };
 
 // Mock auth0

--- a/web/src/__tests__/components/RecommendedSchedule/ScheduleDeleteRowButton.test.tsx
+++ b/web/src/__tests__/components/RecommendedSchedule/ScheduleDeleteRowButton.test.tsx
@@ -7,8 +7,8 @@ const mockReminder = {
   reminderId: '1',
   planId: '1',
   description: 'Reminder 1',
-  startTime: '2024-02-27T08:00:00.000Z',
-  endTime: '2024-02-27T08:30:00.000Z'
+  startTime: new Date('2024-02-27T08:00:00.000Z'),
+  endTime: new Date('2024-02-27T08:30:00.000Z')
 };
 
 const onSubmitMock = jest.fn();

--- a/web/src/__tests__/components/RecommendedSchedule/ScheduleDeleteRowButton.test.tsx
+++ b/web/src/__tests__/components/RecommendedSchedule/ScheduleDeleteRowButton.test.tsx
@@ -2,9 +2,8 @@ import '@testing-library/jest-dom';
 import '../../../util/setupDomTests';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import ScheduleDeleteRowButton from '../../../components/RecommendedSchedule/ScheduleDeleteRowButton';
-import { Reminder } from '../../../components/RecommendedSchedule/RecommendedSchedule';
 
-const mockReminder: Reminder = {
+const mockReminder = {
   reminderId: '1',
   planId: '1',
   description: 'Reminder 1',

--- a/web/src/__tests__/components/RecommendedSchedule/ScheduleEditRowButton.test.tsx
+++ b/web/src/__tests__/components/RecommendedSchedule/ScheduleEditRowButton.test.tsx
@@ -2,14 +2,13 @@ import '@testing-library/jest-dom';
 import '../../../util/setupDomTests';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import ScheduleEditRowButton from '../../../components/RecommendedSchedule/ScheduleEditRowButton';
-import { Reminder } from '../../../components/RecommendedSchedule/RecommendedSchedule';
 
 // Mock the TimePickerField component
 jest.mock('../../../components/TimePickerField', () => () => (
   <div data-testid="mocked-time-picker">Mocked TimePickerField</div>
 ));
 
-const mockReminder: Reminder = {
+const mockReminder = {
   reminderId: '1',
   planId: '1',
   description: 'Reminder 1',

--- a/web/src/__tests__/components/RecommendedSchedule/ScheduleEditRowButton.test.tsx
+++ b/web/src/__tests__/components/RecommendedSchedule/ScheduleEditRowButton.test.tsx
@@ -12,8 +12,8 @@ const mockReminder = {
   reminderId: '1',
   planId: '1',
   description: 'Reminder 1',
-  startTime: '2024-02-27T08:00:00.000Z',
-  endTime: '2024-02-27T08:30:00.000Z'
+  startTime: new Date('2024-02-27T08:00:00.000Z'),
+  endTime: new Date('2024-02-27T08:30:00.000Z')
 };
 
 const onSubmitMock = jest.fn();

--- a/web/src/__tests__/pages/AdminPage.test.tsx
+++ b/web/src/__tests__/pages/AdminPage.test.tsx
@@ -4,37 +4,63 @@ import { screen, act, render, waitFor } from '@testing-library/react';
 import AdminPage from '../../pages/AdminPage';
 import { BrowserRouter } from 'react-router-dom';
 import API_URL from '../../util/apiURL';
+import { UserWithBabies } from '../../types/schemaExtensions';
 
 // Mock fetch
-const mockUserData = [
+const mockUserData: UserWithBabies[] = [
   {
     userId: '1',
     coachId: '3',
     first_name: 'John',
     last_name: 'Doe',
     role: 'client',
-    babies: [{ name: 'Baby1', babyId: '1' }]
+    email: 'johndoe@test.com',
+    babies: [
+      {
+        dob: new Date('2023-01-01'),
+        babyId: '1',
+        name: 'Baby A',
+        parentId: '12345',
+        weight: 8,
+        medicine: ''
+      }
+    ]
   },
   {
     userId: '2',
+    coachId: null,
     first_name: 'Jane',
     last_name: 'Smith',
     role: 'coach',
-    clients: []
+    email: 'janesmith@test.com',
+    babies: []
   },
   {
     userId: '3',
+    coachId: null,
     first_name: 'John',
     last_name: 'Smith',
     role: 'coach',
-    clients: ['1']
+    email: 'johnsmith@test.com',
+    babies: []
   },
   {
     userId: '4',
+    coachId: null,
     first_name: 'Jane',
     last_name: 'Doe',
     role: 'client',
-    babies: [{ name: 'Baby1', babyId: '1' }]
+    email: 'janedoe@test.com',
+    babies: [
+      {
+        dob: new Date('2023-01-01'),
+        babyId: '1',
+        name: 'Baby A',
+        parentId: '12345',
+        weight: 8,
+        medicine: ''
+      }
+    ]
   }
 ];
 global.fetch = jest.fn().mockResolvedValue({

--- a/web/src/__tests__/pages/AssignPage.test.tsx
+++ b/web/src/__tests__/pages/AssignPage.test.tsx
@@ -4,37 +4,63 @@ import { screen, render, waitFor } from '@testing-library/react';
 import AssignPage from '../../pages/AssignPage';
 import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
 import API_URL from '../../util/apiURL';
+import { UserWithBabies } from '../../types/schemaExtensions';
 
 // Mock fetch
-const mockUserData = [
+const mockUserData: UserWithBabies[] = [
   {
     userId: '1',
     coachId: '3',
     first_name: 'John',
     last_name: 'Doe',
     role: 'client',
-    babies: [{ name: 'Baby1', babyId: '1' }]
+    email: 'johndoe@test.com',
+    babies: [
+      {
+        dob: new Date('2023-01-01'),
+        babyId: '1',
+        name: 'Baby A',
+        parentId: '12345',
+        weight: 8,
+        medicine: ''
+      }
+    ]
   },
   {
     userId: '2',
+    coachId: null,
     first_name: 'Jane',
     last_name: 'Smith',
     role: 'coach',
-    clients: []
+    email: 'janesmith@test.com',
+    babies: []
   },
   {
     userId: '3',
+    coachId: null,
     first_name: 'John',
     last_name: 'Smith',
     role: 'coach',
-    clients: ['1']
+    email: 'johnsmith@test.com',
+    babies: []
   },
   {
     userId: '4',
+    coachId: null,
     first_name: 'Jane',
     last_name: 'Doe',
     role: 'client',
-    babies: [{ name: 'Baby1', babyId: '1' }]
+    email: 'janedoe@test.com',
+    babies: [
+      {
+        dob: new Date('2023-01-01'),
+        babyId: '1',
+        name: 'Baby A',
+        parentId: '12345',
+        weight: 8,
+        medicine: ''
+      }
+    ]
   }
 ];
 

--- a/web/src/__tests__/pages/BabyDetailsPage.test.tsx
+++ b/web/src/__tests__/pages/BabyDetailsPage.test.tsx
@@ -54,9 +54,13 @@ global.fetch = jest.fn().mockResolvedValue({
 });
 
 // Mock useParams
+const useParamsMock = jest
+  .fn()
+  .mockReturnValue({ userId: mockClientData.userId });
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useParams: jest.fn().mockReturnValue({ userId: mockClientData.userId })
+  useParams: () => useParamsMock()
 }));
 
 // Mock auth0

--- a/web/src/__tests__/pages/BabyDetailsPage.test.tsx
+++ b/web/src/__tests__/pages/BabyDetailsPage.test.tsx
@@ -4,6 +4,7 @@ import { screen, act, render, waitFor } from '@testing-library/react';
 import BabyDetailsPage from '../../pages/BabyDetailsPage';
 import BabyDropdown from '../../components/BabyDropdown';
 import API_URL from '../../util/apiURL';
+import { UserWithBabies } from '../../types/schemaExtensions';
 
 // Mock Baby Dropdown Component
 jest.mock('../../components/BabyDropdown');
@@ -20,22 +21,29 @@ jest.mock('../../util/environment.ts', () => ({
 }));
 
 // Mock API responses
-const mockClientData = {
-  id: '2',
+const mockClientData: UserWithBabies = {
+  userId: '2',
+  coachId: '3',
+  email: 'johndoe@test.com',
+  role: 'client',
   first_name: 'John',
   last_name: 'Doe',
   babies: [
     {
-      dob: '2023-01-01',
+      dob: new Date('2023-01-01'),
       babyId: '1',
       name: 'Baby A',
-      parentId: '12345'
+      parentId: '12345',
+      weight: 8,
+      medicine: ''
     },
     {
-      dob: '2023-02-15',
+      dob: new Date('2023-02-15'),
       babyId: '2',
       name: 'Baby B',
-      parentId: '12345'
+      parentId: '12345',
+      weight: 8,
+      medicine: ''
     }
   ]
 };

--- a/web/src/__tests__/pages/BabyDetailsPage.test.tsx
+++ b/web/src/__tests__/pages/BabyDetailsPage.test.tsx
@@ -56,7 +56,7 @@ global.fetch = jest.fn().mockResolvedValue({
 // Mock useParams
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useParams: jest.fn().mockReturnValue({ userId: '1' })
+  useParams: jest.fn().mockReturnValue({ userId: mockClientData.userId })
 }));
 
 // Mock auth0
@@ -75,7 +75,11 @@ describe('BabyDetailsPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          mockClientData.first_name + ' ' + mockClientData.last_name
+        )
+      ).toBeInTheDocument();
     });
   });
 
@@ -95,11 +99,14 @@ describe('BabyDetailsPage', () => {
     });
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(`http://${API_URL}/babies/1`, {
-        headers: {
-          Authorization: 'Bearer mocked-access-token'
+      expect(global.fetch).toHaveBeenCalledWith(
+        `http://${API_URL}/users/${mockClientData.userId}`,
+        {
+          headers: {
+            Authorization: 'Bearer mocked-access-token'
+          }
         }
-      });
+      );
     });
   });
 

--- a/web/src/__tests__/pages/ClientsPage.test.tsx
+++ b/web/src/__tests__/pages/ClientsPage.test.tsx
@@ -4,18 +4,32 @@ import { screen, act, render, waitFor } from '@testing-library/react';
 import ClientsPage from '../../pages/ClientsPage';
 import { BrowserRouter } from 'react-router-dom';
 import API_URL from '../../util/apiURL';
+import { UserWithBabies } from '../../types/schemaExtensions';
 
 // Mock fetch
-const mockClientData = [
+const mockClientData: UserWithBabies[] = [
   {
     userId: '1',
+    coachId: '3',
     first_name: 'John',
     last_name: 'Doe',
     role: 'client',
-    babies: [{ name: 'Baby1', babyId: '1' }]
+    email: 'johndoe@test.com',
+    babies: [
+      {
+        dob: new Date('2023-01-01'),
+        babyId: '1',
+        name: 'Baby A',
+        parentId: '12345',
+        weight: 8,
+        medicine: ''
+      }
+    ]
   },
   {
     userId: '2',
+    coachId: null,
+    email: 'janesmith@test.com',
     first_name: 'Jane',
     last_name: 'Smith',
     role: 'admin',

--- a/web/src/__tests__/pages/ClientsPage.test.tsx
+++ b/web/src/__tests__/pages/ClientsPage.test.tsx
@@ -98,7 +98,7 @@ describe('ClientsPage Component', () => {
       );
     });
     await waitFor(() => {
-      expect(screen.getByText('Baby1')).toBeInTheDocument();
+      expect(screen.getByText('Baby A')).toBeInTheDocument();
     });
   });
 });

--- a/web/src/__tests__/pages/CoachPage.test.tsx
+++ b/web/src/__tests__/pages/CoachPage.test.tsx
@@ -4,37 +4,63 @@ import { screen, render, waitFor } from '@testing-library/react';
 import CoachPage from '../../pages/CoachPage';
 import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
 import API_URL from '../../util/apiURL';
+import { UserWithBabies } from '../../types/schemaExtensions';
 
 // Mock fetch
-const mockUserData = [
+const mockUserData: UserWithBabies[] = [
   {
     userId: '1',
     coachId: '3',
     first_name: 'John',
     last_name: 'Doe',
     role: 'client',
-    babies: [{ name: 'Baby1', babyId: '1' }]
+    email: 'johndoe@test.com',
+    babies: [
+      {
+        dob: new Date('2023-01-01'),
+        babyId: '1',
+        name: 'Baby A',
+        parentId: '12345',
+        weight: 8,
+        medicine: ''
+      }
+    ]
   },
   {
     userId: '2',
+    coachId: null,
     first_name: 'Jane',
     last_name: 'Smith',
     role: 'coach',
-    clients: []
+    email: 'janesmith@test.com',
+    babies: []
   },
   {
     userId: '3',
+    coachId: null,
     first_name: 'John',
     last_name: 'Smith',
     role: 'coach',
-    clients: ['1']
+    email: 'johnsmith@test.com',
+    babies: []
   },
   {
     userId: '4',
+    coachId: null,
     first_name: 'Jane',
     last_name: 'Doe',
     role: 'client',
-    babies: [{ name: 'Baby1', babyId: '1' }]
+    email: 'janedoe@test.com',
+    babies: [
+      {
+        dob: new Date('2023-01-01'),
+        babyId: '1',
+        name: 'Baby A',
+        parentId: '12345',
+        weight: 8,
+        medicine: ''
+      }
+    ]
   }
 ];
 

--- a/web/src/components/BabyDropdown.tsx
+++ b/web/src/components/BabyDropdown.tsx
@@ -7,7 +7,7 @@ import Option from '@mui/joy/Option';
 import Typography from '@mui/joy/Typography';
 import { getAgeInMonth } from '../util/utils';
 import { useNavigate } from 'react-router-dom';
-import { Baby } from '../pages/BabyDetailsPage';
+import { Baby } from '@prisma/client';
 
 interface BabyDropdownProps {
   babies: Baby[];

--- a/web/src/components/BabyDropdown.tsx
+++ b/web/src/components/BabyDropdown.tsx
@@ -5,7 +5,7 @@ import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Select from '@mui/joy/Select';
 import Option from '@mui/joy/Option';
 import Typography from '@mui/joy/Typography';
-import { getAgeInMonth } from '../util/utils';
+import { getAgeInMonthFromDob } from '../util/utils';
 import { useNavigate } from 'react-router-dom';
 import { Baby } from '@prisma/client';
 
@@ -73,7 +73,7 @@ const BabyDropdown: React.FC<BabyDropdownProps> = (props) => {
               paddingInline: '4px',
               fontSize: 'xs'
             }}>
-            {getAgeInMonth(data.dob)}
+            {getAgeInMonthFromDob(data.dob)}
           </Chip>
         </Option>
       ))}

--- a/web/src/components/RecommendedSchedule/RecommendedSchedule.tsx
+++ b/web/src/components/RecommendedSchedule/RecommendedSchedule.tsx
@@ -5,20 +5,7 @@ import ScheduleEditRowButton from './ScheduleEditRowButton';
 import ScheduleDeleteButton from './ScheduleDeleteButton';
 import Box from '@mui/joy/Box';
 import { formatTimeTo12HourFormat } from '../../util/utils';
-
-export interface Reminder {
-  reminderId: string;
-  planId: string;
-  description: string;
-  startTime: string;
-  endTime: string | null;
-}
-export interface Plan {
-  planId: string;
-  clientId: string;
-  coachId: string;
-  reminders: Reminder[];
-}
+import { Plan } from '@prisma/client';
 
 interface RecommendedScheduleProps {
   name: string;

--- a/web/src/components/RecommendedSchedule/RecommendedSchedule.tsx
+++ b/web/src/components/RecommendedSchedule/RecommendedSchedule.tsx
@@ -5,7 +5,7 @@ import ScheduleEditRowButton from './ScheduleEditRowButton';
 import ScheduleDeleteButton from './ScheduleDeleteButton';
 import Box from '@mui/joy/Box';
 import { formatDateTo12HourFormat } from '../../util/utils';
-import { Plan, Reminder } from '@prisma/client';
+import { PlanWithReminders } from '../../types/schemaExtensions';
 
 interface RecommendedScheduleProps {
   name: string;

--- a/web/src/components/RecommendedSchedule/RecommendedSchedule.tsx
+++ b/web/src/components/RecommendedSchedule/RecommendedSchedule.tsx
@@ -4,12 +4,12 @@ import ScheduleDeleteRowButton from './ScheduleDeleteRowButton';
 import ScheduleEditRowButton from './ScheduleEditRowButton';
 import ScheduleDeleteButton from './ScheduleDeleteButton';
 import Box from '@mui/joy/Box';
-import { formatTimeTo12HourFormat } from '../../util/utils';
-import { Plan } from '@prisma/client';
+import { formatDateTo12HourFormat } from '../../util/utils';
+import { Plan, Reminder } from '@prisma/client';
 
 interface RecommendedScheduleProps {
   name: string;
-  schedule: Plan;
+  schedule: PlanWithReminders;
   onChange: () => Promise<void>;
 }
 
@@ -95,11 +95,11 @@ export default function RecommendedSchedule(props: RecommendedScheduleProps) {
               <tr key={reminder.reminderId}>
                 <td>{reminder.description}</td>
                 <td>
-                  {formatTimeTo12HourFormat(reminder.endTime) === ''
-                    ? formatTimeTo12HourFormat(reminder.startTime)
-                    : formatTimeTo12HourFormat(reminder.startTime) +
+                  {formatDateTo12HourFormat(reminder.endTime) === ''
+                    ? formatDateTo12HourFormat(reminder.startTime)
+                    : formatDateTo12HourFormat(reminder.startTime) +
                       ' - ' +
-                      formatTimeTo12HourFormat(reminder.endTime)}
+                      formatDateTo12HourFormat(reminder.endTime)}
                 </td>
                 <td>
                   <Box

--- a/web/src/components/RecommendedSchedule/ScheduleDeleteButton.tsx
+++ b/web/src/components/RecommendedSchedule/ScheduleDeleteButton.tsx
@@ -3,7 +3,7 @@ import { Button } from '@mui/joy';
 import DialogActions from '@mui/material/DialogActions';
 import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
-import { Plan } from './RecommendedSchedule';
+import { Plan } from '@prisma/client';
 import { useAuth0 } from '@auth0/auth0-react';
 
 interface ScheduleEditRowButtonProps {

--- a/web/src/components/RecommendedSchedule/ScheduleDeleteRowButton.tsx
+++ b/web/src/components/RecommendedSchedule/ScheduleDeleteRowButton.tsx
@@ -3,7 +3,7 @@ import { Button } from '@mui/joy';
 import DialogActions from '@mui/material/DialogActions';
 import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
-import { Reminder } from './RecommendedSchedule';
+import { Reminder } from '@prisma/client';
 import { useAuth0 } from '@auth0/auth0-react';
 
 interface ScheduleDeleteRowButtonProps {

--- a/web/src/components/RecommendedSchedule/ScheduleEditRowButton.tsx
+++ b/web/src/components/RecommendedSchedule/ScheduleEditRowButton.tsx
@@ -7,7 +7,7 @@ import dayjs from 'dayjs';
 import DialogContent from '@mui/material/DialogContent';
 import TimePickerField from '../TimePickerField';
 import { Checkbox, FormControlLabel, TextField } from '@mui/material';
-import { Reminder } from './RecommendedSchedule';
+import { Reminder } from '@prisma/client';
 import { useAuth0 } from '@auth0/auth0-react';
 
 interface ScheduleEditRowButtonProps {

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react';
 import { Button, styled } from '@mui/joy';
 import { Link as RouterLink } from 'react-router-dom';
 import API_URL from '../util/apiURL';
-import { User, Baby } from '@prisma/client';
+import { UserWithBabies } from '../types/schemaExtensions';
 
 // prevent the Link styling from overriding the Button highlight color
 const Link = styled(RouterLink)`
@@ -18,7 +18,7 @@ const Link = styled(RouterLink)`
 `;
 
 function AdminPage() {
-  const [usersData, setUsersData] = useState<User[]>([]);
+  const [usersData, setUsersData] = useState<UserWithBabies[]>([]);
   const { getAccessTokenSilently } = useAuth0();
 
   useEffect(() => {

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 import { Button, styled } from '@mui/joy';
 import { Link as RouterLink } from 'react-router-dom';
 import API_URL from '../util/apiURL';
+import { User, Baby } from '@prisma/client';
 
 // prevent the Link styling from overriding the Button highlight color
 const Link = styled(RouterLink)`
@@ -15,21 +16,6 @@ const Link = styled(RouterLink)`
     color: inherit;
   }
 `;
-
-interface Baby {
-  name: string;
-  babyId: string;
-}
-
-interface User {
-  userId: string;
-  first_name: string;
-  last_name: string;
-  role: string;
-  babies: Baby[];
-  coachId?: string;
-  clients: User[];
-}
 
 function AdminPage() {
   const [usersData, setUsersData] = useState<User[]>([]);

--- a/web/src/pages/AssignPage.tsx
+++ b/web/src/pages/AssignPage.tsx
@@ -6,6 +6,7 @@ import { useAuth0 } from '@auth0/auth0-react';
 import CoachCard from '../components/CoachCard';
 import API_URL from '../util/apiURL';
 import { UserWithBabies } from '../types/schemaExtensions';
+import { User } from '@prisma/client';
 
 export default function AssignPage() {
   const [clientData, setClientData] = useState<UserWithBabies | null>(null);

--- a/web/src/pages/AssignPage.tsx
+++ b/web/src/pages/AssignPage.tsx
@@ -5,10 +5,10 @@ import { useEffect, useState } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import CoachCard from '../components/CoachCard';
 import API_URL from '../util/apiURL';
-import { User } from '@prisma/client';
+import { UserWithBabies } from '../types/schemaExtensions';
 
 export default function AssignPage() {
-  const [clientData, setClientData] = useState<User | null>(null);
+  const [clientData, setClientData] = useState<UserWithBabies | null>(null);
   const { clientId } = useParams();
 
   const navigate = useNavigate();

--- a/web/src/pages/AssignPage.tsx
+++ b/web/src/pages/AssignPage.tsx
@@ -5,23 +5,7 @@ import { useEffect, useState } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import CoachCard from '../components/CoachCard';
 import API_URL from '../util/apiURL';
-
-interface Baby {
-  dob: string;
-  babyId: string;
-  name: string;
-  parentId: string;
-}
-
-interface User {
-  userId: string;
-  first_name: string;
-  last_name: string;
-  role: string;
-  babies: Baby[];
-  coachId?: string;
-  clients: User[];
-}
+import { User } from '@prisma/client';
 
 export default function AssignPage() {
   const [clientData, setClientData] = useState<User | null>(null);

--- a/web/src/pages/BabyDetailsPage.tsx
+++ b/web/src/pages/BabyDetailsPage.tsx
@@ -5,20 +5,7 @@ import Box from '@mui/system/Box';
 import { useEffect, useState } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import API_URL from '../util/apiURL';
-
-export interface Baby {
-  dob: string;
-  babyId: string;
-  name: string;
-  parentId: string;
-}
-
-interface User {
-  id: string;
-  first_name: string;
-  last_name: string;
-  babies: Baby[];
-}
+import { User, Baby } from '@prisma/client';
 
 export default function BabyDetailsPage() {
   const [clientData, setClientData] = useState<User | null>(null);

--- a/web/src/pages/BabyDetailsPage.tsx
+++ b/web/src/pages/BabyDetailsPage.tsx
@@ -5,10 +5,10 @@ import Box from '@mui/system/Box';
 import { useEffect, useState } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import API_URL from '../util/apiURL';
-import { User, Baby } from '@prisma/client';
+import { UserWithBabies } from '../types/schemaExtensions';
 
 export default function BabyDetailsPage() {
-  const [clientData, setClientData] = useState<User | null>(null);
+  const [clientData, setClientData] = useState<UserWithBabies | null>(null);
 
   const { getAccessTokenSilently } = useAuth0();
   const { userId } = useParams(); // Access the userId from the route parameters

--- a/web/src/pages/ClientsPage.tsx
+++ b/web/src/pages/ClientsPage.tsx
@@ -3,16 +3,8 @@ import ClientCard from '../components/ClientCard';
 import Grid from '@mui/joy/Grid';
 import Item from '@mui/joy/Grid';
 import { useEffect, useState } from 'react';
-import { Baby } from './BabyDetailsPage';
 import API_URL from '../util/apiURL';
-
-interface User {
-  userId: string;
-  first_name: string;
-  last_name: string;
-  role: string;
-  babies: Baby[];
-}
+import { User } from '@prisma/client';
 
 function ClientsPage() {
   const [usersData, setUsersData] = useState<User[]>([]);

--- a/web/src/pages/ClientsPage.tsx
+++ b/web/src/pages/ClientsPage.tsx
@@ -4,10 +4,10 @@ import Grid from '@mui/joy/Grid';
 import Item from '@mui/joy/Grid';
 import { useEffect, useState } from 'react';
 import API_URL from '../util/apiURL';
-import { User } from '@prisma/client';
+import { UserWithBabies } from '../types/schemaExtensions';
 
 function ClientsPage() {
-  const [usersData, setUsersData] = useState<User[]>([]);
+  const [usersData, setUsersData] = useState<UserWithBabies[]>([]);
   const { getAccessTokenSilently } = useAuth0();
 
   useEffect(() => {

--- a/web/src/pages/CoachPage.tsx
+++ b/web/src/pages/CoachPage.tsx
@@ -6,9 +6,10 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import API_URL from '../util/apiURL';
 import { User } from '@prisma/client';
+import { UserWithBabies } from '../types/schemaExtensions';
 
 function CoachPage() {
-  const [usersData, setUsersData] = useState<User[]>([]);
+  const [usersData, setUsersData] = useState<UserWithBabies[]>([]);
   const [coachData, setCoachData] = useState<User | null>(null);
   const { coachId } = useParams();
 

--- a/web/src/pages/CoachPage.tsx
+++ b/web/src/pages/CoachPage.tsx
@@ -5,20 +5,7 @@ import Item from '@mui/joy/Grid';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import API_URL from '../util/apiURL';
-
-interface Baby {
-  name: string;
-  babyId: string;
-}
-
-interface User {
-  userId: string;
-  first_name: string;
-  last_name: string;
-  role: string;
-  babies: Baby[];
-  coachId?: string;
-}
+import { User } from '@prisma/client';
 
 function CoachPage() {
   const [usersData, setUsersData] = useState<User[]>([]);

--- a/web/src/pages/ErrorPage.tsx
+++ b/web/src/pages/ErrorPage.tsx
@@ -1,4 +1,4 @@
-import { useRouteError } from 'react-router-dom';
+import { useRouteError, isRouteErrorResponse } from 'react-router-dom';
 
 export default function ErrorPage() {
   const error = useRouteError();
@@ -9,7 +9,11 @@ export default function ErrorPage() {
       <h1>Oops!</h1>
       <p>Sorry, an unexpected error has occurred.</p>
       <p>
-        <i>{error.statusText || error.message}</i>
+        <i>
+          {isRouteErrorResponse(error)
+            ? error.statusText
+            : 'Unknown Error Message'}
+        </i>
       </p>
     </div>
   );

--- a/web/src/types/schemaExtensions.tsx
+++ b/web/src/types/schemaExtensions.tsx
@@ -1,0 +1,9 @@
+import { User, Baby, Plan, Reminder } from '@prisma/client';
+
+export interface UserWithBabies extends User {
+  babies: Baby[];
+}
+
+export interface PlanWithReminders extends Plan {
+  reminders: Reminder[];
+}

--- a/web/src/util/utils.ts
+++ b/web/src/util/utils.ts
@@ -43,6 +43,22 @@ export function getAgeInMonth(dob: string): string {
   return ageYears * 12 + ageMonths + 'M';
 }
 
+export function formatDateTo12HourFormat(date: Date | null) {
+  if (date === null) {
+    return '';
+  }
+
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+
+  const formattedHours = hours % 12 || 12;
+  const formattedMinutes = minutes < 10 ? `0${minutes}` : minutes;
+  const period = hours < 12 ? 'AM' : 'PM';
+
+  const formattedTime = `${formattedHours}:${formattedMinutes} ${period}`;
+  return formattedTime;
+}
+
 export function formatTimeTo12HourFormat(dateString: string | null) {
   if (dateString === null) {
     return '';

--- a/web/src/util/utils.ts
+++ b/web/src/util/utils.ts
@@ -28,6 +28,20 @@ export function toggleSidebar() {
   }
 }
 
+export function getAgeInMonthFromDob(dob: Date): string {
+  const today = new Date();
+
+  let ageYears = today.getFullYear() - dob.getFullYear();
+  let ageMonths = today.getMonth() - dob.getMonth();
+
+  if (ageMonths < 0) {
+    ageYears--;
+    ageMonths += 12;
+  }
+
+  return ageYears * 12 + ageMonths + 'M';
+}
+
 export function getAgeInMonth(dob: string): string {
   const today = new Date();
   const birthDate = new Date(dob);


### PR DESCRIPTION
## Describe your changes
Instead of declaring types in a decentralized way that is likely to lag behind actual schema implementation, import database types directly from the Prisma client.  To follow this new paradigm, I now recommend importing any schema types you use in a component from '@prisma/client' and extending from those types if associations are included in the JSON response data.

## JIRA Ticket Link
https://septeam4.atlassian.net/browse/T4-95

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Is the code correctly formatted?
- [ ] If this is a feature, is there a related Notion document for the feature?
